### PR TITLE
Add github action for publishing to npm

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: "24"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org/"
 
       - name: Install dependencies


### PR DESCRIPTION
Add github action workflow for publishing to npm when a tag with version is pushed.

Resolves #4 