### PR TITLE
Refactor token emitter

### DIFF
--- a/ios/ExpoLiveActivityModule.swift
+++ b/ios/ExpoLiveActivityModule.swift
@@ -141,8 +141,9 @@ public class ExpoLiveActivityModule: Module {
   private func observePushToStartToken() {
     guard #available(iOS 17.2, *), ActivityAuthorizationInfo().areActivitiesEnabled else { return }
 
-    let initialToken = Activity<LiveActivityAttributes>.pushToStartToken.reduce("") { $0 + String(format: "%02x", $1) }
-    sendPushToStartToken(activityPushToStartToken: initialToken)
+    if let initialToken = (Activity<LiveActivityAttributes>.pushToStartToken?.reduce("") { $0 + String(format: "%02x", $1) }) {
+      sendPushToStartToken(activityPushToStartToken: initialToken)
+    }
 
     print("Observing push to start token updates...")
     Task {
@@ -210,10 +211,6 @@ public class ExpoLiveActivityModule: Module {
     }
 
     Events("onTokenReceived", "onPushToStartTokenReceived", "onStateChange")
-
-    Property("pushToStartToken") {
-      return Activity<LiveActivityAttributes>.pushToStartToken.reduce("") { $0 + String(format: "%02x", $1) }
-    }
 
     Function("startActivity") {
       (state: LiveActivityState, maybeConfig: LiveActivityConfig?) -> String in

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,7 @@ export type ActivityTokenReceivedEvent = {
 }
 
 export type ActivityPushToStartTokenReceivedEvent = {
-  activityPushToStartToken: string
+  activityPushToStartToken: string | null
 }
 
 type ActivityState = 'active' | 'dismissed' | 'pending' | 'stale' | 'ended'
@@ -181,21 +181,34 @@ export function updateActivity(id: string, state: LiveActivityState) {
   if (assertIOS('updateActivity')) return ExpoLiveActivityModule.updateActivity(id, state)
 }
 
+/**
+ * @param {function} updateTokenListener The listener function that will be called when an update token is received.
+ */
 export function addActivityTokenListener(
-  listener: (event: ActivityTokenReceivedEvent) => void
+  updateTokenListener: (event: ActivityTokenReceivedEvent) => void
 ): Voidable<EventSubscription> {
-  if (assertIOS('addActivityTokenListener')) return ExpoLiveActivityModule.addListener('onTokenReceived', listener)
+  if (assertIOS('addActivityTokenListener'))
+    return ExpoLiveActivityModule.addListener('onTokenReceived', updateTokenListener)
 }
 
+/**
+ * Adds a listener that is called when a push-to-start token is received. Supported only on iOS > 17.2.
+ * On earlier iOS versions, the listener will return null as a token.
+ * @param {function} pushPushToStartTokenListener The listener function that will be called when the observer starts and then when a push-to-start token is received.
+ */
 export function addActivityPushToStartTokenListener(
-  listener: (event: ActivityPushToStartTokenReceivedEvent) => void
+  pushPushToStartTokenListener: (event: ActivityPushToStartTokenReceivedEvent) => void
 ): Voidable<EventSubscription> {
   if (assertIOS('addActivityPushToStartTokenListener'))
-    return ExpoLiveActivityModule.addListener('onPushToStartTokenReceived', listener)
+    return ExpoLiveActivityModule.addListener('onPushToStartTokenReceived', pushPushToStartTokenListener)
 }
 
+/**
+ * @param {function} statusListener The listener function that will be called when an activity status changes.
+ */
 export function addActivityUpdatesListener(
-  listener: (event: ActivityUpdateEvent) => void
+  statusListener: (event: ActivityUpdateEvent) => void
 ): Voidable<EventSubscription> {
-  if (assertIOS('addActivityUpdatesListener')) return ExpoLiveActivityModule.addListener('onStateChange', listener)
+  if (assertIOS('addActivityUpdatesListener'))
+    return ExpoLiveActivityModule.addListener('onStateChange', statusListener)
 }


### PR DESCRIPTION
This is an unfinished PR – don't merge without testing fully and adding OnStopObserving to stop the native Task

# Motivation

We've had a customer that found it hard to use this module to get pushToStartTokens.

The listener triggered only on fresh app install, also there was no way to delay the listener subscription till after signin.

# Changes suggested

I'd suggest revamping the code to use OnStartObserving, OnStopObserving fully, and having the listener always emit a token on subscription (not only when the native events happen)

I'd also suggest exposing current tokens as properties.