### PR TITLE
Add elapsed timer support (timerStartDateInMilliseconds)

### DIFF
--- a/ios-files/Date+toTimerInterval.swift
+++ b/ios-files/Date+toTimerInterval.swift
@@ -4,4 +4,8 @@ extension Date {
   static func toTimerInterval(miliseconds: Double) -> ClosedRange<Self> {
     now ... max(now, Date(timeIntervalSince1970: miliseconds / 1000))
   }
+
+  static func toElapsedTimerInterval(miliseconds: Double) -> ClosedRange<Self> {
+    Date(timeIntervalSince1970: miliseconds / 1000) ... now
+  }
 }

--- a/ios-files/LiveActivityView.swift
+++ b/ios-files/LiveActivityView.swift
@@ -212,6 +212,13 @@ import WidgetKit
                 ProgressView(timerInterval: Date.toTimerInterval(miliseconds: date))
                   .tint(progressViewTint)
                   .modifier(ConditionalForegroundViewModifier(color: attributes.progressViewLabelColor))
+              } else if let startDate = contentState.timerStartDateInMilliseconds {
+                HStack(spacing: 4) {
+                  Text("Elapsed:")
+                  Text(Date(timeIntervalSince1970: startDate / 1000), style: .timer)
+                    .fontWeight(.semibold)
+                }
+                .modifier(ConditionalForegroundViewModifier(color: attributes.progressViewLabelColor))
               } else if let progress = contentState.progress {
                 ProgressView(value: progress)
                   .tint(progressViewTint)
@@ -233,6 +240,13 @@ import WidgetKit
             ProgressView(timerInterval: Date.toTimerInterval(miliseconds: date))
               .tint(progressViewTint)
               .modifier(ConditionalForegroundViewModifier(color: attributes.progressViewLabelColor))
+          } else if let startDate = contentState.timerStartDateInMilliseconds {
+            HStack(spacing: 4) {
+              Text("Elapsed:")
+              Text(Date(timeIntervalSince1970: startDate / 1000), style: .timer)
+                .fontWeight(.semibold)
+            }
+            .modifier(ConditionalForegroundViewModifier(color: attributes.progressViewLabelColor))
           } else if let progress = contentState.progress {
             ProgressView(value: progress)
               .tint(progressViewTint)

--- a/ios/ExpoLiveActivityModule.swift
+++ b/ios/ExpoLiveActivityModule.swift
@@ -17,6 +17,9 @@ public class ExpoLiveActivityModule: Module {
       var date: Double?
 
       @Field
+      var startDate: Double?
+
+      @Field
       var progress: Double?
     }
 
@@ -256,6 +259,7 @@ public class ExpoLiveActivityModule: Module {
           title: state.title,
           subtitle: state.subtitle,
           timerEndDateInMilliseconds: state.progressBar?.date,
+          timerStartDateInMilliseconds: state.progressBar?.startDate,
           progress: state.progressBar?.progress
         )
 
@@ -292,6 +296,7 @@ public class ExpoLiveActivityModule: Module {
           title: state.title,
           subtitle: state.subtitle,
           timerEndDateInMilliseconds: state.progressBar?.date,
+          timerStartDateInMilliseconds: state.progressBar?.startDate,
           progress: state.progressBar?.progress
         )
         try await updateImages(state: state, newState: &newState)
@@ -319,6 +324,7 @@ public class ExpoLiveActivityModule: Module {
           title: state.title,
           subtitle: state.subtitle,
           timerEndDateInMilliseconds: state.progressBar?.date,
+          timerStartDateInMilliseconds: state.progressBar?.startDate,
           progress: state.progressBar?.progress
         )
         try await updateImages(state: state, newState: &newState)

--- a/ios/LiveActivityAttributes.swift
+++ b/ios/LiveActivityAttributes.swift
@@ -6,6 +6,7 @@ struct LiveActivityAttributes: ActivityAttributes {
     var title: String
     var subtitle: String?
     var timerEndDateInMilliseconds: Double?
+    var timerStartDateInMilliseconds: Double?
     var progress: Double?
     var imageName: String?
     var dynamicIslandImageName: String?

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,10 +10,12 @@ export type DynamicIslandTimerType = 'circular' | 'digital'
 type ProgressBarType =
   | {
       date?: number
+      startDate?: number
       progress?: undefined
     }
   | {
       date?: undefined
+      startDate?: undefined
       progress?: number
     }
 
@@ -29,6 +31,7 @@ export type NativeLiveActivityState = {
   title: string
   subtitle?: string
   date?: number
+  startDate?: number
   progress?: number
   imageName?: string
   dynamicIslandImageName?: string


### PR DESCRIPTION
Add support for elapsed timers that count UP from a start date, in addition to the existing countdown timers. This enables use cases like showing time worked since clock-in, which auto-updates even when the phone is locked.

Changes:
- Add startDate field to ProgressBarType in TypeScript
- Add timerStartDateInMilliseconds to ContentState in Swift
- Add toElapsedTimerInterval() Date extension for elapsed time ranges
- Add compactElapsedTimer and dynamicIslandExpandedBottomElapsed views
- Update LiveActivityView to display elapsed timer on lock screen

Usage: Pass progressBar.startDate (timestamp in ms) instead of progressBar.date