### PR TITLE
Add Mintfile for SwiftFormat

### DIFF
--- a/Mintfile
+++ b/Mintfile
@@ -1,0 +1,1 @@
+nicklockwood/SwiftFormat@0.58.7

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "clean": "expo-module clean",
     "clean:plugin": "rm -rf plugin/build plugin/tsconfig.tsbuildinfo",
     "format:check": "prettier --check .",
+    "format:swift": "swiftformat ios/ ios-files/",
     "lint": "expo-module eslint",
     "lint:libOnly": "expo-module eslint --ignore-pattern 'example/*'",
     "test": "expo-module test",


### PR DESCRIPTION
Adds SwiftFormat 0.58.7 via Mint for consistent Swift code formatting across the team. Also adds npm script `format:swift` for convenience.