### PR TITLE
Fix countdown timer default in example app

### DIFF
--- a/example/screens/CreateLiveActivityScreen.tsx
+++ b/example/screens/CreateLiveActivityScreen.tsx
@@ -31,7 +31,7 @@ export default function CreateLiveActivityScreen() {
   const [title, onChangeTitle] = useState('Title')
   const [subtitle, onChangeSubtitle] = useState('This is a subtitle')
   const [imageName, onChangeImageName] = useState('logo')
-  const [date, setDate] = useState(new Date())
+  const [date, setDate] = useState(new Date(Date.now() + 5 * 60 * 1000))
   const [isTimerTypeDigital, setTimerTypeDigital] = useState(false)
   const [progress, setProgress] = useState('0.5')
   const [passSubtitle, setPassSubtitle] = useState(true)


### PR DESCRIPTION
## Problem
The countdown timer in the example app defaults to `new Date()` (current time). When a user starts a live activity with the countdown enabled, the timer immediately shows `0:00` because the target time has already passed.

This makes the demo appear broken on first use.

## Fix
Initialize the date picker to 5 minutes in the future so the countdown timer works as expected out of the box.

## Test plan
- [x] Start app fresh, tap "Start Activity" with countdown enabled
- [x] Timer now shows ~5:00 and counts down properly