### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The module comes with a built-in config plugin that creates a target in iOS with
      }
    }
    ```
-   If you want to update Live Acitivity with push notifications you can add option `"enablePushNotifications": true`:
+   If you want to update Live Activity with push notifications you can add option `"enablePushNotifications": true`:
    ```json
    {
      "expo": {

--- a/example/screens/CreateLiveActivityScreen.tsx
+++ b/example/screens/CreateLiveActivityScreen.tsx
@@ -229,7 +229,7 @@ export default function CreateLiveActivityScreen() {
           <Switch onValueChange={() => setPassSubtitle(toggle)} value={passSubtitle} />
         </View>
         <TextInput
-          style={passSubtitle ? styles.input : styles.diabledInput}
+          style={passSubtitle ? styles.input : styles.disabledInput}
           onChangeText={onChangeSubtitle}
           placeholder="Live activity title"
           value={subtitle}
@@ -242,7 +242,7 @@ export default function CreateLiveActivityScreen() {
           <Switch onValueChange={() => setPassImage(toggle)} value={passImage} />
         </View>
         <TextInput
-          style={passImage ? styles.input : styles.diabledInput}
+          style={passImage ? styles.input : styles.disabledInput}
           onChangeText={onChangeImageName}
           autoCapitalize="none"
           placeholder="Live activity image"
@@ -451,7 +451,7 @@ export default function CreateLiveActivityScreen() {
               />
             </View>
             <TextInput
-              style={passProgress ? styles.input : styles.diabledInput}
+              style={passProgress ? styles.input : styles.disabledInput}
               onChangeText={onChangeProgress}
               keyboardType="numeric"
               placeholder="Progress (0-1)"
@@ -526,7 +526,7 @@ const styles = StyleSheet.create({
     borderRadius: 10,
     padding: 10,
   },
-  diabledInput: {
+  disabledInput: {
     height: 45,
     width: '90%',
     margin: 12,

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,13 +194,13 @@ export function addActivityTokenListener(
 /**
  * Adds a listener that is called when a push-to-start token is received. Supported only on iOS > 17.2.
  * On earlier iOS versions, the listener will return null as a token.
- * @param {function} pushPushToStartTokenListener The listener function that will be called when the observer starts and then when a push-to-start token is received.
+ * @param {function} listener The listener function that will be called when the observer starts and then when a push-to-start token is received.
  */
 export function addActivityPushToStartTokenListener(
-  pushPushToStartTokenListener: (event: ActivityPushToStartTokenReceivedEvent) => void
+  listener: (event: ActivityPushToStartTokenReceivedEvent) => void
 ): Voidable<EventSubscription> {
   if (assertIOS('addActivityPushToStartTokenListener'))
-    return ExpoLiveActivityModule.addListener('onPushToStartTokenReceived', pushPushToStartTokenListener)
+    return ExpoLiveActivityModule.addListener('onPushToStartTokenReceived', listener)
 }
 
 /**


### PR DESCRIPTION
## Summary
- Rename `pushPushToStartTokenListener` → `listener` (duplicate "push" in parameter name)
- Fix "Live Acitivity" → "Live Activity" in README
- Fix `diabledInput` → `disabledInput` in example app styles