### PR TITLE
ImageSize type update

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The `config` object should include:
    padding?: Padding // number | {top?: number bottom?: number ...}
    imagePosition?: ImagePosition; // 'left' | 'right';
    imageAlign?: ImageAlign; // 'top' | 'center' | 'bottom'
-   imageSize?: ImageSize // { width: number|`${number}%`, height: number|`${number}%` } | undefined (defaults to 64pt)
+   imageSize?: ImageSize // { width?: number|`${number}%`, height?: number|`${number}%` } | undefined (defaults to 64pt)
    contentFit?: ImageContentFit; // 'cover' | 'contain' | 'fill' | 'none' | 'scale-down'
 };
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,8 +75,8 @@ export type ImageAlign = 'top' | 'center' | 'bottom'
 
 export type ImageDimension = number | `${number}%`
 export type ImageSize = {
-  width: ImageDimension
-  height: ImageDimension
+  width?: ImageDimension
+  height?: ImageDimension
 }
 
 export type ImageContentFit = 'cover' | 'contain' | 'fill' | 'none' | 'scale-down'


### PR DESCRIPTION
Implemented changes:

We're making width and height optional because the API and UI already allow sending only one dimension (e.g just width). Normalisation and Swift handle missing values safely (defaulting/aspect-ratio), and this avoids unsafe casts while matching real world usage.