### PR TITLE
silent failing support

### DIFF
--- a/ios/ExpoLiveActivityModule.swift
+++ b/ios/ExpoLiveActivityModule.swift
@@ -236,6 +236,11 @@ public class ExpoLiveActivityModule: Module {
       ?? false
   }
 
+  private var silentOnUnsupportedOS: Bool {
+    Bundle.main.object(forInfoDictionaryKey: "ExpoLiveActivity_SilentOnUnsupportedOS") as? Bool
+      ?? false
+  }
+
   public func definition() -> ModuleDefinition {
     Name("ExpoLiveActivity")
 
@@ -253,7 +258,12 @@ public class ExpoLiveActivityModule: Module {
 
     Function("startActivity") {
       (state: LiveActivityState, maybeConfig: LiveActivityConfig?) -> String in
-      guard #available(iOS 16.2, *) else { throw UnsupportedOSException("16.2") }
+      guard #available(iOS 16.2, *) else {
+        if silentOnUnsupportedOS {
+          return ""
+        }
+        throw UnsupportedOSException("16.2")
+      }
 
       guard ActivityAuthorizationInfo().areActivitiesEnabled else {
         throw LiveActivitiesNotEnabledException()
@@ -329,7 +339,12 @@ public class ExpoLiveActivityModule: Module {
     }
 
     Function("stopActivity") { (activityId: String, state: LiveActivityState) in
-      guard #available(iOS 16.2, *) else { throw UnsupportedOSException("16.2") }
+      guard #available(iOS 16.2, *) else {
+        if silentOnUnsupportedOS {
+          return
+        }
+        throw UnsupportedOSException("16.2")
+      }
 
       guard
         let activity = Activity<LiveActivityAttributes>.activities.first(where: {
@@ -361,6 +376,9 @@ public class ExpoLiveActivityModule: Module {
 
     Function("updateActivity") { (activityId: String, state: LiveActivityState) in
       guard #available(iOS 16.2, *) else {
+        if silentOnUnsupportedOS {
+          return
+        }
         throw UnsupportedOSException("16.2")
       }
 

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -4,6 +4,7 @@ import type { LiveActivityConfigPlugin } from './types'
 import { withConfig } from './withConfig'
 import withPlist from './withPlist'
 import { withPushNotifications } from './withPushNotifications'
+import { withUnsupportedOS } from './withUnsupportedOS'
 import { withWidgetExtensionEntitlements } from './withWidgetExtensionEntitlements'
 import { withXcode } from './withXcode'
 
@@ -38,6 +39,8 @@ const withWidgetsAndLiveActivities: LiveActivityConfigPlugin = (config, props) =
   if (props?.enablePushNotifications) {
     config = withPushNotifications(config)
   }
+
+  config = withUnsupportedOS(config, { silentOnUnsupportedOS: props?.silentOnUnsupportedOS ?? false })
 
   return config
 }

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -2,6 +2,7 @@ import { ConfigPlugin } from '@expo/config-plugins'
 
 interface ConfigPluginProps {
   enablePushNotifications?: boolean
+  silentOnUnsupportedOS?: boolean
 }
 
 export type LiveActivityConfigPlugin = ConfigPlugin<ConfigPluginProps | undefined>

--- a/plugin/src/withUnsupportedOS.ts
+++ b/plugin/src/withUnsupportedOS.ts
@@ -1,0 +1,10 @@
+import { ConfigPlugin, withInfoPlist } from '@expo/config-plugins'
+
+export const withUnsupportedOS: ConfigPlugin<{ silentOnUnsupportedOS: boolean }> = (
+  config,
+  { silentOnUnsupportedOS }
+) =>
+  withInfoPlist(config, (mod) => {
+    mod.modResults['ExpoLiveActivity_SilentOnUnsupportedOS'] = silentOnUnsupportedOS
+    return mod
+  })


### PR DESCRIPTION

On iOS devices that do not support Live Activity, an error was being thrown unconditionally, even though this situation wasn't an unexpected failure.

**Implemented changes:**
Following the feedback, I've added an optional flag that allows for a silent fail when the minimum iOS version guard is not met.