### PR TITLE
Compact trailing subtitle fallback + configurable showsHours

### DIFF
--- a/example/screens/CreateLiveActivityScreen.tsx
+++ b/example/screens/CreateLiveActivityScreen.tsx
@@ -37,7 +37,7 @@ export default function CreateLiveActivityScreen() {
   const [progress, setProgress] = useState('0.5')
   const [passSubtitle, setPassSubtitle] = useState(true)
   const [passImage, setPassImage] = useState(true)
-  const [passDate, setPassDate] = useState(true)
+  const [passDate, setPassDate] = useState(false)
   const [passProgress, setPassProgress] = useState(false)
   const [passElapsedTimer, setPassElapsedTimer] = useState(false)
   const [elapsedTimerMinutesAgo, setElapsedTimerMinutesAgo] = useState('5')

--- a/example/screens/CreateLiveActivityScreen.tsx
+++ b/example/screens/CreateLiveActivityScreen.tsx
@@ -41,6 +41,7 @@ export default function CreateLiveActivityScreen() {
   const [passProgress, setPassProgress] = useState(false)
   const [passElapsedTimer, setPassElapsedTimer] = useState(false)
   const [elapsedTimerMinutesAgo, setElapsedTimerMinutesAgo] = useState('5')
+  const [showsHours, setShowsHours] = useState(true)
   const [imageWidth, setImageWidth] = useState('')
   const [imageHeight, setImageHeight] = useState('')
   const [smallImageName, onChangeSmallImageName] = useState('')
@@ -174,6 +175,7 @@ export default function CreateLiveActivityScreen() {
       return {
         elapsedTimer: {
           startDate: Date.now() - (parseInt(elapsedTimerMinutesAgo, 10) || 5) * 60 * 1000,
+          showsHours,
         },
       }
     }
@@ -570,6 +572,10 @@ export default function CreateLiveActivityScreen() {
                   placeholder="Minutes ago (e.g. 5)"
                   value={elapsedTimerMinutesAgo}
                 />
+                <View style={styles.labelWithSwitch}>
+                  <Text style={styles.label}>Show hours:</Text>
+                  <Switch onValueChange={() => setShowsHours(toggle)} value={showsHours} />
+                </View>
               </>
             )}
             <View style={styles.spacer} />

--- a/ios-files/LiveActivityMediumView.swift
+++ b/ios-files/LiveActivityMediumView.swift
@@ -67,7 +67,8 @@ struct LiveActivityMediumView: View {
             } else if let startDate = contentState.elapsedTimerStartDateInMilliseconds {
               ElapsedTimerText(
                 startTimeMilliseconds: startDate,
-                color: attributes.progressViewLabelColor.map { Color(hex: $0) }
+                color: attributes.progressViewLabelColor.map { Color(hex: $0) },
+                showsHours: contentState.elapsedTimerShowsHours ?? true
               )
               .font(.title3)
               .fontWeight(.medium)
@@ -105,7 +106,8 @@ struct LiveActivityMediumView: View {
         } else if let startDate = contentState.elapsedTimerStartDateInMilliseconds {
           ElapsedTimerText(
             startTimeMilliseconds: startDate,
-            color: attributes.progressViewLabelColor.map { Color(hex: $0) }
+            color: attributes.progressViewLabelColor.map { Color(hex: $0) },
+            showsHours: contentState.elapsedTimerShowsHours ?? true
           )
           .font(.title2)
           .fontWeight(.semibold)

--- a/ios-files/LiveActivitySmallView.swift
+++ b/ios-files/LiveActivitySmallView.swift
@@ -92,7 +92,8 @@ import WidgetKit
                 if let startDate = contentState.elapsedTimerStartDateInMilliseconds {
                   ElapsedTimerText(
                     startTimeMilliseconds: startDate,
-                    color: attributes.progressViewLabelColor.map { Color(hex: $0) }
+                    color: attributes.progressViewLabelColor.map { Color(hex: $0) },
+                    showsHours: contentState.elapsedTimerShowsHours ?? true
                   )
                   .font(carPlayView
                     ? (isSubtitleDisplayed ? .footnote : .title2)

--- a/ios-files/LiveActivityWidget.swift
+++ b/ios-files/LiveActivityWidget.swift
@@ -224,6 +224,15 @@ public struct LiveActivityWidget: Widget {
             progress: progress,
             progressViewTint: context.attributes.progressViewTint
           ).applyWidgetURL(from: context.attributes.deepLinkUrl)
+        } else if let subtitle = context.state.subtitle {
+          Text(subtitle)
+            .font(.system(size: 13))
+            .minimumScaleFactor(0.8)
+            .fontWeight(.semibold)
+            .frame(maxWidth: 60)
+            .multilineTextAlignment(.trailing)
+            .foregroundStyle(.white)
+            .applyWidgetURL(from: context.attributes.deepLinkUrl)
         }
       } minimal: {
         if let startDate = context.state.elapsedTimerStartDateInMilliseconds {
@@ -355,7 +364,7 @@ struct ElapsedTimerText: View {
       timerInterval: startTime ... Date.distantFuture,
       pauseTime: nil,
       countsDown: false,
-      showsHours: true
+      showsHours: false
     )
     .monospacedDigit()
     .foregroundStyle(color ?? .primary)

--- a/ios-files/LiveActivityWidget.swift
+++ b/ios-files/LiveActivityWidget.swift
@@ -12,6 +12,7 @@ public struct LiveActivityAttributes: ActivityAttributes {
     var dynamicIslandImageName: String?
     var smallImageName: String?
     var elapsedTimerStartDateInMilliseconds: Double?
+    var elapsedTimerShowsHours: Bool?
     var currentStep: Int?
     var totalSteps: Int?
 
@@ -24,6 +25,7 @@ public struct LiveActivityAttributes: ActivityAttributes {
       dynamicIslandImageName: String? = nil,
       smallImageName: String? = nil,
       elapsedTimerStartDateInMilliseconds: Double? = nil,
+      elapsedTimerShowsHours: Bool? = nil,
       currentStep: Int? = nil,
       totalSteps: Int? = nil
     ) {
@@ -35,6 +37,7 @@ public struct LiveActivityAttributes: ActivityAttributes {
       self.dynamicIslandImageName = dynamicIslandImageName
       self.smallImageName = smallImageName
       self.elapsedTimerStartDateInMilliseconds = elapsedTimerStartDateInMilliseconds
+      self.elapsedTimerShowsHours = elapsedTimerShowsHours
       self.currentStep = currentStep
       self.totalSteps = totalSteps
     }
@@ -174,7 +177,8 @@ public struct LiveActivityWidget: Widget {
           if let startDate = context.state.elapsedTimerStartDateInMilliseconds {
             ElapsedTimerText(
               startTimeMilliseconds: startDate,
-              color: context.attributes.progressViewTint.map { Color(hex: $0) } ?? .white
+              color: context.attributes.progressViewTint.map { Color(hex: $0) } ?? .white,
+              showsHours: context.state.elapsedTimerShowsHours ?? true
             )
             .font(.title2)
             .fontWeight(.semibold)
@@ -205,7 +209,8 @@ public struct LiveActivityWidget: Widget {
         if let startDate = context.state.elapsedTimerStartDateInMilliseconds {
           ElapsedTimerText(
             startTimeMilliseconds: startDate,
-            color: nil
+            color: nil,
+            showsHours: context.state.elapsedTimerShowsHours ?? true
           )
           .font(.system(size: 15))
           .minimumScaleFactor(0.8)
@@ -238,7 +243,8 @@ public struct LiveActivityWidget: Widget {
         if let startDate = context.state.elapsedTimerStartDateInMilliseconds {
           ElapsedTimerText(
             startTimeMilliseconds: startDate,
-            color: context.attributes.progressViewTint.map { Color(hex: $0) }
+            color: context.attributes.progressViewTint.map { Color(hex: $0) },
+            showsHours: context.state.elapsedTimerShowsHours ?? true
           )
           .font(.system(size: 11))
           .minimumScaleFactor(0.6)
@@ -352,6 +358,7 @@ public struct LiveActivityWidget: Widget {
 struct ElapsedTimerText: View {
   let startTimeMilliseconds: Double
   let color: Color?
+  var showsHours: Bool = true
 
   private var startTime: Date {
     Date(timeIntervalSince1970: startTimeMilliseconds / 1000)
@@ -364,7 +371,7 @@ struct ElapsedTimerText: View {
       timerInterval: startTime ... Date.distantFuture,
       pauseTime: nil,
       countsDown: false,
-      showsHours: false
+      showsHours: showsHours
     )
     .monospacedDigit()
     .foregroundStyle(color ?? .primary)

--- a/ios/ExpoLiveActivityModule.swift
+++ b/ios/ExpoLiveActivityModule.swift
@@ -31,6 +31,9 @@ public class ExpoLiveActivityModule: Module {
       struct ElapsedTimer: Record {
         @Field
         var startDate: Double?
+
+        @Field
+        var showsHours: Bool?
       }
     }
 
@@ -316,6 +319,7 @@ public class ExpoLiveActivityModule: Module {
           dynamicIslandImageName: state.dynamicIslandImageName,
           smallImageName: state.smallImageName,
           elapsedTimerStartDateInMilliseconds: state.progressBar?.elapsedTimer?.startDate,
+          elapsedTimerShowsHours: state.progressBar?.elapsedTimer?.showsHours,
           currentStep: state.progressBar?.currentStep,
           totalSteps: state.progressBar?.totalSteps
         )
@@ -363,6 +367,7 @@ public class ExpoLiveActivityModule: Module {
           dynamicIslandImageName: state.dynamicIslandImageName,
           smallImageName: state.smallImageName,
           elapsedTimerStartDateInMilliseconds: state.progressBar?.elapsedTimer?.startDate,
+          elapsedTimerShowsHours: state.progressBar?.elapsedTimer?.showsHours,
           currentStep: state.progressBar?.currentStep,
           totalSteps: state.progressBar?.totalSteps
         )
@@ -399,6 +404,7 @@ public class ExpoLiveActivityModule: Module {
           dynamicIslandImageName: state.dynamicIslandImageName,
           smallImageName: state.smallImageName,
           elapsedTimerStartDateInMilliseconds: state.progressBar?.elapsedTimer?.startDate,
+          elapsedTimerShowsHours: state.progressBar?.elapsedTimer?.showsHours,
           currentStep: state.progressBar?.currentStep,
           totalSteps: state.progressBar?.totalSteps
         )

--- a/ios/LiveActivityAttributes.swift
+++ b/ios/LiveActivityAttributes.swift
@@ -11,6 +11,7 @@ struct LiveActivityAttributes: ActivityAttributes {
     var dynamicIslandImageName: String?
     var smallImageName: String?
     var elapsedTimerStartDateInMilliseconds: Double?
+    var elapsedTimerShowsHours: Bool?
     var currentStep: Int?
     var totalSteps: Int?
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export type DynamicIslandTimerType = 'circular' | 'digital'
 
 export type ElapsedTimer = {
   startDate: number // milliseconds timestamp (past time when timer started)
+  showsHours?: boolean // whether to display the hours component (e.g. 1:05:00 vs 65:00)
 }
 
 type ProgressBarType =


### PR DESCRIPTION
## Summary
- **Subtitle fallback in compact trailing** — When no timer/progress is active, the Dynamic Island compact trailing now displays the subtitle text instead of being empty.
- **Configurable `showsHours`** — The elapsed timer's `showsHours` is now configurable from JS (defaults to `true`). Consumers can set it to `false` to hide the `00:` hours prefix for a more compact display.
- Demo controls added in the example app for the new `showsHours` toggle.

## Test plan
- [ ] Start activity with elapsed timer + `showsHours` on → timer shows `0:05:23`
- [ ] Toggle `showsHours` off, update activity → timer shows `05:23`
- [ ] Disable all timers/progress, keep subtitle enabled → subtitle appears in compact trailing
- [ ] Verify `npm run lint` passes
- [ ] Verify `npm run typecheck` passes