### PR TITLE
Add getRunningActivities to fix push token race condition

### DIFF
--- a/ios/ExpoLiveActivityModule.swift
+++ b/ios/ExpoLiveActivityModule.swift
@@ -256,6 +256,35 @@ public class ExpoLiveActivityModule: Module {
 
     Events("onTokenReceived", "onPushToStartTokenReceived", "onStateChange")
 
+    Function("getRunningActivities") { () -> [[String: String]] in
+      guard #available(iOS 16.2, *) else {
+        if self.silentOnUnsupportedOS {
+          return []
+        }
+        throw UnsupportedOSException("16.2")
+      }
+
+      var results: [[String: String]] = []
+
+      for activity in Activity<LiveActivityAttributes>.activities {
+        var entry: [String: String] = [
+          "activityID": activity.id,
+          "activityName": activity.attributes.name,
+          "activityState": String(describing: activity.activityState),
+        ]
+
+        if self.pushNotificationsEnabled, let pushToken = activity.pushToken {
+          entry["activityPushToken"] = pushToken.reduce("") {
+            $0 + String(format: "%02x", $1)
+          }
+        }
+
+        results.append(entry)
+      }
+
+      return results
+    }
+
     Function("startActivity") {
       (state: LiveActivityState, maybeConfig: LiveActivityConfig?, relevanceScore: Double?) -> String in
       guard #available(iOS 16.2, *) else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,6 +118,13 @@ export type ActivityUpdateEvent = {
   activityState: ActivityState
 }
 
+export type RunningActivity = {
+  activityID: string
+  activityName: string
+  activityState: ActivityState
+  activityPushToken?: string
+}
+
 export type LiveActivityModuleEvents = {
   onTokenReceived: (params: ActivityTokenReceivedEvent) => void
   onPushToStartTokenReceived: (params: ActivityPushToStartTokenReceivedEvent) => void
@@ -229,6 +236,15 @@ export function stopActivity(id: string, state: LiveActivityState, relevanceScor
  */
 export function updateActivity(id: string, state: LiveActivityState, relevanceScore?: number) {
   if (assertIOS('updateActivity')) return ExpoLiveActivityModule.updateActivity(id, state, relevanceScore)
+}
+
+/**
+ * Returns all running Live Activities and their current push tokens.
+ * Use this after registering addActivityTokenListener to catch tokens
+ * for activities that were already running before the listener was ready.
+ */
+export function getRunningActivities(): Voidable<RunningActivity[]> {
+  if (assertIOS('getRunningActivities')) return ExpoLiveActivityModule.getRunningActivities()
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds a synchronous `getRunningActivities()` function that returns all current Live Activities with their push tokens
- Fixes a race condition where push tokens for push-to-started activities are lost on cold start because the native `pushTokenUpdates` stream emits before the JS listener is registered
- Uses `activity.pushToken` (synchronous `Data?` property) to read current tokens without relying on async streams

## Context

On cold start with an existing push-to-started activity:

1. Native observation starts → `activityUpdates` emits the already-running activity → `pushTokenUpdates` emits the current token
2. The token event fires before the JS listener is registered → lost
3. The JS listener is registered → nothing to receive

The fix lets consumers query current tokens after registering the listener:

```typescript
const sub = addActivityTokenListener((event) => {
  registerToken(event.activityID, event.activityPushToken)
})

const activities = getRunningActivities()
activities?.forEach((a) => {
  if (a.activityPushToken) {
    registerToken(a.activityID, a.activityPushToken)
  }
})
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)