### PR TITLE
Feat/url schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ LiveActivity.startActivity(state, {
 })
 ```
 
-URL scheme will be taken automatically from `scheme` field in `app.json` or fall back to `ios.bundleIdentifier`.
+URL scheme will be taken automatically from `scheme` field in `app.json`/`app.config.js` or fall back to `ios.bundleIdentifier`.
 
 ### State Object Structure
 

--- a/plugin/src/lib/addUrlSchemeToInfoPlist.ts
+++ b/plugin/src/lib/addUrlSchemeToInfoPlist.ts
@@ -1,0 +1,32 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+/**
+ * Injects CFBundleURLTypes into the widget target's Info.plist if not already present.
+ * This allows the widget extension to share the app's URL scheme for deep linking.
+ */
+export function addUrlSchemeToInfoPlist(targetPath: string, scheme: string): void {
+  const infoPlistPath = path.join(targetPath, 'Info.plist')
+
+  if (!fs.existsSync(infoPlistPath)) return
+
+  const plistContent = fs.readFileSync(infoPlistPath, 'utf8')
+
+  if (plistContent.includes('CFBundleURLTypes')) return
+
+  const urlTypes = [
+    `\t<key>CFBundleURLTypes</key>`,
+    `\t<array>`,
+    `\t\t<dict>`,
+    `\t\t\t<key>CFBundleURLSchemes</key>`,
+    `\t\t\t<array>`,
+    `\t\t\t\t<string>${scheme}</string>`,
+    `\t\t\t</array>`,
+    `\t\t</dict>`,
+    `\t</array>`,
+  ].join('\n')
+
+  const updatedContent = plistContent.replace(/(<\/dict>\s*<\/plist>)/, `${urlTypes}\n$1`)
+
+  fs.writeFileSync(infoPlistPath, updatedContent, 'utf8')
+}

--- a/plugin/src/withXcode.ts
+++ b/plugin/src/withXcode.ts
@@ -1,6 +1,7 @@
 import { ConfigPlugin, withXcodeProject } from '@expo/config-plugins'
 import * as path from 'path'
 
+import { addUrlSchemeToInfoPlist } from './lib/addUrlSchemeToInfoPlist'
 import { getWidgetFiles } from './lib/getWidgetFiles'
 import { addBuildPhases } from './xcode/addBuildPhases'
 import { addPbxGroup } from './xcode/addPbxGroup'
@@ -25,6 +26,17 @@ export const withXcode: ConfigPlugin<{
     const targetPath = path.join(platformProjectRoot, targetName)
 
     const widgetFiles = getWidgetFiles(targetPath)
+
+    const scheme =
+      typeof config.scheme === 'string'
+        ? config.scheme
+        : Array.isArray(config.scheme)
+          ? config.scheme[0]
+          : config.ios?.bundleIdentifier
+
+    if (scheme) {
+      addUrlSchemeToInfoPlist(targetPath, scheme)
+    }
 
     const xCConfigurationList = addXCConfigurationList(xcodeProject, {
       targetName,


### PR DESCRIPTION
## Problem

Deep links triggered from a Live Activity widget fail silently because the widget extension's `Info.plist` does not contain `CFBundleURLTypes`. Without a registered URL scheme, iOS cannot route the link back to the host app.

In Expo projects that use `app.config.js` instead of `app.json`, the scheme may not be automatically resolved during plugin execution, causing the URL scheme to never be added to the widget target.

## Solution

Resolve the app scheme directly from the Expo config (`app.json` or `app.config.js`) during the Xcode configuration step and inject `CFBundleURLTypes` into the widget extension's `Info.plist` when missing.

Scheme resolution follows this order:

1. `expo.scheme` (string)
2. first entry of `expo.scheme` (array)
3. fallback to `ios.bundleIdentifier`

This ensures the widget extension shares the same URL scheme as the host app, allowing deep links from Live Activities to open the app correctly.

## Changes

- Added `plugin/src/lib/addUrlSchemeToInfoPlist.ts` to handle `Info.plist` patching
- Updated `plugin/src/withXcode.ts` to resolve the scheme from Expo config and call the helper

## Notes

- No additional configuration required
- Injection is idempotent
- No breaking changes