### PR TITLE
fix: prevent content shift when progressBar is absent in LiveActivityMediumView

### DIFF
--- a/ios-files/LiveActivityMediumView.swift
+++ b/ios-files/LiveActivityMediumView.swift
@@ -123,5 +123,6 @@ struct LiveActivityMediumView: View {
       }
     }
     .padding(padding)
+    .frame(maxWidth: .infinity, alignment: .leading)
   }
 }


### PR DESCRIPTION
## Problem

When the Live Activity state has no `progressBar` (e.g. during a paused state), the content in the lock screen notification banner shifts to the right.

**Root cause:** The `ElapsedTimerText` / `ProgressView` elements rendered below the title/subtitle row have `.frame(maxWidth: .infinity)`, which forces the outer `VStack` to fill the notification container width. When those elements are absent, the `VStack` shrinks to its content width and iOS centers it horizontally — making the title/subtitle appear shifted right.

## Fix

Add `.frame(maxWidth: .infinity, alignment: .leading)` to the outer `VStack` in `LiveActivityMediumView.swift` so it always fills available width regardless of whether a progress/timer element is present.

```swift
// Before
VStack(alignment: .leading) { ... }
  .padding(padding)

// After  
VStack(alignment: .leading) { ... }
  .padding(padding)
  .frame(maxWidth: .infinity, alignment: .leading)
```

## Reproduction

1. Start a Live Activity with `progressBar: { elapsedTimer: ... }`
2. Update the activity with no `progressBar` (e.g. a paused state)
3. Observe the title/subtitle shift right on the lock screen banner

## Screenshot
<img width="293" height="633" alt="demo" src="https://github.com/user-attachments/assets/0e33496f-ad9e-427e-9eb8-2a8d0cbbcf0b" />


#### With fix
<img width="293" alt="IMG_9645" src="https://github.com/user-attachments/assets/41578612-e1c2-4df0-bb36-74e29bd07694" />

