### PR TITLE
feat: support combined elapsedTimer + progress in progressBar

### DIFF
--- a/example/screens/CreateLiveActivityScreen.tsx
+++ b/example/screens/CreateLiveActivityScreen.tsx
@@ -41,6 +41,8 @@ export default function CreateLiveActivityScreen() {
   const [passProgress, setPassProgress] = useState(false)
   const [passElapsedTimer, setPassElapsedTimer] = useState(false)
   const [elapsedTimerMinutesAgo, setElapsedTimerMinutesAgo] = useState('5')
+  const [passElapsedTimerEndDate, setPassElapsedTimerEndDate] = useState(false)
+  const [elapsedTimerDurationMinutes, setElapsedTimerDurationMinutes] = useState('30')
   const [imageWidth, setImageWidth] = useState('')
   const [imageHeight, setImageHeight] = useState('')
   const [smallImageName, onChangeSmallImageName] = useState('')
@@ -171,11 +173,11 @@ export default function CreateLiveActivityScreen() {
     }
 
     if (passElapsedTimer) {
-      return {
-        elapsedTimer: {
-          startDate: Date.now() - (parseInt(elapsedTimerMinutesAgo, 10) || 5) * 60 * 1000,
-        },
-      }
+      const startDate = Date.now() - (parseInt(elapsedTimerMinutesAgo, 10) || 5) * 60 * 1000
+      const endDate = passElapsedTimerEndDate
+        ? startDate + (parseInt(elapsedTimerDurationMinutes, 10) || 30) * 60 * 1000
+        : undefined
+      return { elapsedTimer: { startDate, endDate } }
     }
 
     if (passProgress) {
@@ -569,6 +571,18 @@ export default function CreateLiveActivityScreen() {
                   keyboardType="number-pad"
                   placeholder="Minutes ago (e.g. 5)"
                   value={elapsedTimerMinutesAgo}
+                />
+                <View style={styles.labelWithSwitch}>
+                  <Text style={styles.label}>Show total duration (endDate):</Text>
+                  <Switch onValueChange={() => setPassElapsedTimerEndDate(toggle)} value={passElapsedTimerEndDate} />
+                </View>
+                <TextInput
+                  style={passElapsedTimerEndDate ? styles.input : styles.disabledInput}
+                  onChangeText={(t) => onChangeNumeric(t, setElapsedTimerDurationMinutes)}
+                  keyboardType="number-pad"
+                  placeholder="Total duration in minutes (e.g. 30)"
+                  value={elapsedTimerDurationMinutes}
+                  editable={passElapsedTimerEndDate}
                 />
               </>
             )}

--- a/ios-files/LiveActivityMediumView.swift
+++ b/ios-files/LiveActivityMediumView.swift
@@ -134,6 +134,7 @@ struct LiveActivityMediumView: View {
         }
       }
     }
+    .frame(maxWidth: .infinity, alignment: .leading)
     .padding(padding)
   }
 }

--- a/ios-files/LiveActivityMediumView.swift
+++ b/ios-files/LiveActivityMediumView.swift
@@ -81,9 +81,8 @@ struct LiveActivityMediumView: View {
                 HStack(spacing: 4) {
                   ElapsedTimerText(startTimeMilliseconds: startDate, color: labelColor)
                   Text("/ \(formattedDuration(startMs: startDate, endMs: endDate))")
-                    .foregroundStyle(labelColor ?? .primary)
                 }
-                .monospacedDigit()
+                .foregroundStyle(labelColor ?? .primary)
                 .font(.title3)
                 .fontWeight(.medium)
               } else {
@@ -130,9 +129,8 @@ struct LiveActivityMediumView: View {
             HStack(spacing: 4) {
               ElapsedTimerText(startTimeMilliseconds: startDate, color: labelColor)
               Text("/ \(formattedDuration(startMs: startDate, endMs: endDate))")
-                .foregroundStyle(labelColor ?? .primary)
             }
-            .monospacedDigit()
+            .foregroundStyle(labelColor ?? .primary)
             .font(.title2)
             .fontWeight(.semibold)
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/ios-files/LiveActivityMediumView.swift
+++ b/ios-files/LiveActivityMediumView.swift
@@ -27,17 +27,6 @@ struct LiveActivityMediumView: View {
     attributes.progressViewTint.map { Color(hex: $0) }
   }
 
-  private func formattedDuration(startMs: Double, endMs: Double) -> String {
-    let totalSeconds = Int((endMs - startMs) / 1000)
-    let hours = totalSeconds / 3600
-    let minutes = (totalSeconds % 3600) / 60
-    let seconds = totalSeconds % 60
-    if hours > 0 {
-      return String(format: "%d:%02d:%02d", hours, minutes, seconds)
-    }
-    return String(format: "%d:%02d", minutes, seconds)
-  }
-
   var body: some View {
     let padding = attributes.resolvedPadding(defaultPadding: 24)
 
@@ -76,20 +65,13 @@ struct LiveActivityMediumView: View {
                 inactiveColor: attributes.segmentInactiveColor
               )
             } else if let startDate = contentState.elapsedTimerStartDateInMilliseconds {
-              let labelColor = attributes.progressViewLabelColor.map { Color(hex: $0) }
-              if let endDate = contentState.elapsedTimerEndDateInMilliseconds {
-                HStack(spacing: 4) {
-                  ElapsedTimerText(startTimeMilliseconds: startDate, color: labelColor)
-                  Text("/ \(formattedDuration(startMs: startDate, endMs: endDate))")
-                }
-                .foregroundStyle(labelColor ?? .primary)
-                .font(.title3)
-                .fontWeight(.medium)
-              } else {
-                ElapsedTimerText(startTimeMilliseconds: startDate, color: labelColor)
-                  .font(.title3)
-                  .fontWeight(.medium)
-              }
+              ElapsedTimerText(
+                startTimeMilliseconds: startDate,
+                endTimeMilliseconds: contentState.elapsedTimerEndDateInMilliseconds,
+                color: attributes.progressViewLabelColor.map { Color(hex: $0) }
+              )
+              .font(.title3)
+              .fontWeight(.medium)
             } else if let date = contentState.timerEndDateInMilliseconds {
               ProgressView(timerInterval: Date.toTimerInterval(miliseconds: date))
                 .tint(progressViewTint)
@@ -122,33 +104,24 @@ struct LiveActivityMediumView: View {
             inactiveColor: attributes.segmentInactiveColor
           )
         } else if let startDate = contentState.elapsedTimerStartDateInMilliseconds {
-          let labelColor = attributes.progressViewLabelColor.map { Color(hex: $0) }
+          ElapsedTimerText(
+            startTimeMilliseconds: startDate,
+            endTimeMilliseconds: contentState.elapsedTimerEndDateInMilliseconds,
+            color: attributes.progressViewLabelColor.map { Color(hex: $0) }
+          )
+          .font(.title2)
+          .fontWeight(.semibold)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .padding(.top, 4)
           if let endDate = contentState.elapsedTimerEndDateInMilliseconds {
-            let startD = Date(timeIntervalSince1970: startDate / 1000)
-            let endD = Date(timeIntervalSince1970: endDate / 1000)
-            HStack(spacing: 4) {
-              ElapsedTimerText(startTimeMilliseconds: startDate, color: labelColor)
-              Text("/ \(formattedDuration(startMs: startDate, endMs: endDate))")
-            }
-            .foregroundStyle(labelColor ?? .primary)
-            .font(.title2)
-            .fontWeight(.semibold)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.top, 4)
             styledLinearProgressView(tint: progressViewTint, labelColor: attributes.progressViewLabelColor) {
               ProgressView(
-                timerInterval: startD...endD,
+                timerInterval: Date(timeIntervalSince1970: startDate / 1000)...Date(timeIntervalSince1970: endDate / 1000),
                 countsDown: false,
                 label: { EmptyView() },
                 currentValueLabel: { EmptyView() }
               )
             }
-          } else {
-            ElapsedTimerText(startTimeMilliseconds: startDate, color: labelColor)
-              .font(.title2)
-              .fontWeight(.semibold)
-              .frame(maxWidth: .infinity, alignment: .leading)
-              .padding(.top, 4)
           }
         } else if let date = contentState.timerEndDateInMilliseconds {
           ProgressView(timerInterval: Date.toTimerInterval(miliseconds: date))

--- a/ios-files/LiveActivityMediumView.swift
+++ b/ios-files/LiveActivityMediumView.swift
@@ -111,6 +111,11 @@ struct LiveActivityMediumView: View {
           .fontWeight(.semibold)
           .frame(maxWidth: .infinity, alignment: .leading)
           .padding(.top, 4)
+          if let progress = contentState.progress {
+            ProgressView(value: progress)
+              .tint(progressViewTint)
+              .padding(.top, 2)
+          }
         } else if let date = contentState.timerEndDateInMilliseconds {
           ProgressView(timerInterval: Date.toTimerInterval(miliseconds: date))
             .tint(progressViewTint)

--- a/ios-files/LiveActivityMediumView.swift
+++ b/ios-files/LiveActivityMediumView.swift
@@ -27,6 +27,17 @@ struct LiveActivityMediumView: View {
     attributes.progressViewTint.map { Color(hex: $0) }
   }
 
+  private func formattedDuration(startMs: Double, endMs: Double) -> String {
+    let totalSeconds = Int((endMs - startMs) / 1000)
+    let hours = totalSeconds / 3600
+    let minutes = (totalSeconds % 3600) / 60
+    let seconds = totalSeconds % 60
+    if hours > 0 {
+      return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+    }
+    return String(format: "%d:%02d", minutes, seconds)
+  }
+
   var body: some View {
     let padding = attributes.resolvedPadding(defaultPadding: 24)
 
@@ -65,12 +76,21 @@ struct LiveActivityMediumView: View {
                 inactiveColor: attributes.segmentInactiveColor
               )
             } else if let startDate = contentState.elapsedTimerStartDateInMilliseconds {
-              ElapsedTimerText(
-                startTimeMilliseconds: startDate,
-                color: attributes.progressViewLabelColor.map { Color(hex: $0) }
-              )
-              .font(.title3)
-              .fontWeight(.medium)
+              let labelColor = attributes.progressViewLabelColor.map { Color(hex: $0) }
+              if let endDate = contentState.elapsedTimerEndDateInMilliseconds {
+                HStack(spacing: 4) {
+                  ElapsedTimerText(startTimeMilliseconds: startDate, color: labelColor)
+                  Text("/ \(formattedDuration(startMs: startDate, endMs: endDate))")
+                    .foregroundStyle(labelColor ?? .primary)
+                }
+                .monospacedDigit()
+                .font(.title3)
+                .fontWeight(.medium)
+              } else {
+                ElapsedTimerText(startTimeMilliseconds: startDate, color: labelColor)
+                  .font(.title3)
+                  .fontWeight(.medium)
+              }
             } else if let date = contentState.timerEndDateInMilliseconds {
               ProgressView(timerInterval: Date.toTimerInterval(miliseconds: date))
                 .tint(progressViewTint)
@@ -103,18 +123,34 @@ struct LiveActivityMediumView: View {
             inactiveColor: attributes.segmentInactiveColor
           )
         } else if let startDate = contentState.elapsedTimerStartDateInMilliseconds {
-          ElapsedTimerText(
-            startTimeMilliseconds: startDate,
-            color: attributes.progressViewLabelColor.map { Color(hex: $0) }
-          )
-          .font(.title2)
-          .fontWeight(.semibold)
-          .frame(maxWidth: .infinity, alignment: .leading)
-          .padding(.top, 4)
-          if let progress = contentState.progress {
-            ProgressView(value: progress)
-              .tint(progressViewTint)
-              .padding(.top, 2)
+          let labelColor = attributes.progressViewLabelColor.map { Color(hex: $0) }
+          if let endDate = contentState.elapsedTimerEndDateInMilliseconds {
+            let startD = Date(timeIntervalSince1970: startDate / 1000)
+            let endD = Date(timeIntervalSince1970: endDate / 1000)
+            HStack(spacing: 4) {
+              ElapsedTimerText(startTimeMilliseconds: startDate, color: labelColor)
+              Text("/ \(formattedDuration(startMs: startDate, endMs: endDate))")
+                .foregroundStyle(labelColor ?? .primary)
+            }
+            .monospacedDigit()
+            .font(.title2)
+            .fontWeight(.semibold)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.top, 4)
+            styledLinearProgressView(tint: progressViewTint, labelColor: attributes.progressViewLabelColor) {
+              ProgressView(
+                timerInterval: startD...endD,
+                countsDown: false,
+                label: { EmptyView() },
+                currentValueLabel: { EmptyView() }
+              )
+            }
+          } else {
+            ElapsedTimerText(startTimeMilliseconds: startDate, color: labelColor)
+              .font(.title2)
+              .fontWeight(.semibold)
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .padding(.top, 4)
           }
         } else if let date = contentState.timerEndDateInMilliseconds {
           ProgressView(timerInterval: Date.toTimerInterval(miliseconds: date))

--- a/ios-files/LiveActivitySmallView.swift
+++ b/ios-files/LiveActivitySmallView.swift
@@ -43,7 +43,9 @@ import WidgetKit
     private var shouldShowProgressBar: Bool {
       let hasProgress = contentState.progress != nil
       let hasTimer = contentState.timerEndDateInMilliseconds != nil
-      return hasProgress || (hasTimer && !isSubtitleDisplayed && !isTimerShownAsText) || contentState.hasSegmentedProgress
+      let hasElapsedWithEnd = contentState.elapsedTimerStartDateInMilliseconds != nil
+        && contentState.elapsedTimerEndDateInMilliseconds != nil
+      return hasProgress || (hasTimer && !isSubtitleDisplayed && !isTimerShownAsText) || contentState.hasSegmentedProgress || hasElapsedWithEnd
     }
 
     var body: some View {
@@ -90,15 +92,33 @@ import WidgetKit
                 }
 
                 if let startDate = contentState.elapsedTimerStartDateInMilliseconds {
-                  ElapsedTimerText(
-                    startTimeMilliseconds: startDate,
-                    color: attributes.progressViewLabelColor.map { Color(hex: $0) }
-                  )
-                  .font(carPlayView
+                  let labelColor = attributes.progressViewLabelColor.map { Color(hex: $0) }
+                  let font: Font = carPlayView
                     ? (isSubtitleDisplayed ? .footnote : .title2)
-                    : (isSubtitleDisplayed ? .footnote : .callout))
-                  .fontWeight(carPlayView && !isSubtitleDisplayed ? .semibold : .medium)
-                  .padding(.top, isSubtitleDisplayed ? 3 : 0)
+                    : (isSubtitleDisplayed ? .footnote : .callout)
+                  if let endDate = contentState.elapsedTimerEndDateInMilliseconds {
+                    let totalSeconds = Int((endDate - startDate) / 1000)
+                    let hours = totalSeconds / 3600
+                    let minutes = (totalSeconds % 3600) / 60
+                    let seconds = totalSeconds % 60
+                    let durationLabel = hours > 0
+                      ? String(format: "%d:%02d:%02d", hours, minutes, seconds)
+                      : String(format: "%d:%02d", minutes, seconds)
+                    HStack(spacing: 4) {
+                      ElapsedTimerText(startTimeMilliseconds: startDate, color: labelColor)
+                      Text("/ \(durationLabel)")
+                        .foregroundStyle(labelColor ?? .primary)
+                    }
+                    .monospacedDigit()
+                    .font(font)
+                    .fontWeight(carPlayView && !isSubtitleDisplayed ? .semibold : .medium)
+                    .padding(.top, isSubtitleDisplayed ? 3 : 0)
+                  } else {
+                    ElapsedTimerText(startTimeMilliseconds: startDate, color: labelColor)
+                      .font(font)
+                      .fontWeight(carPlayView && !isSubtitleDisplayed ? .semibold : .medium)
+                      .padding(.top, isSubtitleDisplayed ? 3 : 0)
+                  }
                 } else if let date = contentState.timerEndDateInMilliseconds, !isTimerShownAsText, !(carPlayView && isSubtitleDisplayed) {
                   smallTimerText(endDate: date, isSubtitleDisplayed: isSubtitleDisplayed, carPlayView: carPlayView, labelColor: attributes.progressViewLabelColor)
                 }
@@ -140,6 +160,17 @@ import WidgetKit
                   inactiveColor: attributes.segmentInactiveColor,
                   height: 6
                 ).padding(.bottom, 6)
+              } else if let startDate = contentState.elapsedTimerStartDateInMilliseconds,
+                        let endDate = contentState.elapsedTimerEndDateInMilliseconds
+              {
+                styledLinearProgressView(tint: progressViewTint, labelColor: attributes.progressViewLabelColor) {
+                  ProgressView(
+                    timerInterval: Date(timeIntervalSince1970: startDate / 1000)...Date(timeIntervalSince1970: endDate / 1000),
+                    countsDown: false,
+                    label: { EmptyView() },
+                    currentValueLabel: { EmptyView() }
+                  )
+                }
               } else if let progress = contentState.progress {
                 styledLinearProgressView(tint: progressViewTint, labelColor: attributes.progressViewLabelColor) {
                   ProgressView(value: progress)

--- a/ios-files/LiveActivitySmallView.swift
+++ b/ios-files/LiveActivitySmallView.swift
@@ -107,9 +107,8 @@ import WidgetKit
                     HStack(spacing: 4) {
                       ElapsedTimerText(startTimeMilliseconds: startDate, color: labelColor)
                       Text("/ \(durationLabel)")
-                        .foregroundStyle(labelColor ?? .primary)
                     }
-                    .monospacedDigit()
+                    .foregroundStyle(labelColor ?? .primary)
                     .font(font)
                     .fontWeight(carPlayView && !isSubtitleDisplayed ? .semibold : .medium)
                     .padding(.top, isSubtitleDisplayed ? 3 : 0)

--- a/ios-files/LiveActivitySmallView.swift
+++ b/ios-files/LiveActivitySmallView.swift
@@ -92,32 +92,16 @@ import WidgetKit
                 }
 
                 if let startDate = contentState.elapsedTimerStartDateInMilliseconds {
-                  let labelColor = attributes.progressViewLabelColor.map { Color(hex: $0) }
-                  let font: Font = carPlayView
+                  ElapsedTimerText(
+                    startTimeMilliseconds: startDate,
+                    endTimeMilliseconds: contentState.elapsedTimerEndDateInMilliseconds,
+                    color: attributes.progressViewLabelColor.map { Color(hex: $0) }
+                  )
+                  .font(carPlayView
                     ? (isSubtitleDisplayed ? .footnote : .title2)
-                    : (isSubtitleDisplayed ? .footnote : .callout)
-                  if let endDate = contentState.elapsedTimerEndDateInMilliseconds {
-                    let totalSeconds = Int((endDate - startDate) / 1000)
-                    let hours = totalSeconds / 3600
-                    let minutes = (totalSeconds % 3600) / 60
-                    let seconds = totalSeconds % 60
-                    let durationLabel = hours > 0
-                      ? String(format: "%d:%02d:%02d", hours, minutes, seconds)
-                      : String(format: "%d:%02d", minutes, seconds)
-                    HStack(spacing: 4) {
-                      ElapsedTimerText(startTimeMilliseconds: startDate, color: labelColor)
-                      Text("/ \(durationLabel)")
-                    }
-                    .foregroundStyle(labelColor ?? .primary)
-                    .font(font)
-                    .fontWeight(carPlayView && !isSubtitleDisplayed ? .semibold : .medium)
-                    .padding(.top, isSubtitleDisplayed ? 3 : 0)
-                  } else {
-                    ElapsedTimerText(startTimeMilliseconds: startDate, color: labelColor)
-                      .font(font)
-                      .fontWeight(carPlayView && !isSubtitleDisplayed ? .semibold : .medium)
-                      .padding(.top, isSubtitleDisplayed ? 3 : 0)
-                  }
+                    : (isSubtitleDisplayed ? .footnote : .callout))
+                  .fontWeight(carPlayView && !isSubtitleDisplayed ? .semibold : .medium)
+                  .padding(.top, isSubtitleDisplayed ? 3 : 0)
                 } else if let date = contentState.timerEndDateInMilliseconds, !isTimerShownAsText, !(carPlayView && isSubtitleDisplayed) {
                   smallTimerText(endDate: date, isSubtitleDisplayed: isSubtitleDisplayed, carPlayView: carPlayView, labelColor: attributes.progressViewLabelColor)
                 }

--- a/ios-files/LiveActivityWidget.swift
+++ b/ios-files/LiveActivityWidget.swift
@@ -367,8 +367,7 @@ struct ElapsedTimerText: View {
       Text(
         timerInterval: startTime ... Date.distantFuture,
         pauseTime: nil,
-        countsDown: false,
-        showsHours: true
+        countsDown: false
       )
       if let label = durationLabel {
         Text("/ \(label)")

--- a/ios-files/LiveActivityWidget.swift
+++ b/ios-files/LiveActivityWidget.swift
@@ -12,6 +12,7 @@ public struct LiveActivityAttributes: ActivityAttributes {
     var dynamicIslandImageName: String?
     var smallImageName: String?
     var elapsedTimerStartDateInMilliseconds: Double?
+    var elapsedTimerEndDateInMilliseconds: Double?
     var currentStep: Int?
     var totalSteps: Int?
 
@@ -24,6 +25,7 @@ public struct LiveActivityAttributes: ActivityAttributes {
       dynamicIslandImageName: String? = nil,
       smallImageName: String? = nil,
       elapsedTimerStartDateInMilliseconds: Double? = nil,
+      elapsedTimerEndDateInMilliseconds: Double? = nil,
       currentStep: Int? = nil,
       totalSteps: Int? = nil
     ) {
@@ -35,6 +37,7 @@ public struct LiveActivityAttributes: ActivityAttributes {
       self.dynamicIslandImageName = dynamicIslandImageName
       self.smallImageName = smallImageName
       self.elapsedTimerStartDateInMilliseconds = elapsedTimerStartDateInMilliseconds
+      self.elapsedTimerEndDateInMilliseconds = elapsedTimerEndDateInMilliseconds
       self.currentStep = currentStep
       self.totalSteps = totalSteps
     }

--- a/ios-files/LiveActivityWidget.swift
+++ b/ios-files/LiveActivityWidget.swift
@@ -342,21 +342,38 @@ public struct LiveActivityWidget: Widget {
 
 struct ElapsedTimerText: View {
   let startTimeMilliseconds: Double
+  var endTimeMilliseconds: Double? = nil
   let color: Color?
 
   private var startTime: Date {
     Date(timeIntervalSince1970: startTimeMilliseconds / 1000)
   }
 
+  private var durationLabel: String? {
+    guard let endMs = endTimeMilliseconds else { return nil }
+    let totalSeconds = Int((endMs - startTimeMilliseconds) / 1000)
+    let hours = totalSeconds / 3600
+    let minutes = (totalSeconds % 3600) / 60
+    let seconds = totalSeconds % 60
+    return hours > 0
+      ? String(format: "%d:%02d:%02d", hours, minutes, seconds)
+      : String(format: "%d:%02d", minutes, seconds)
+  }
+
   var body: some View {
-    // Use Text with timerInterval for Live Activities - iOS handles the updates automatically
-    // The range goes from startTime to a far future date, with countsDown: false to count UP
-    Text(
-      timerInterval: startTime ... Date.distantFuture,
-      pauseTime: nil,
-      countsDown: false,
-      showsHours: true
-    )
+    HStack(spacing: 4) {
+      // Use Text with timerInterval for Live Activities - iOS handles the updates automatically
+      // The range goes from startTime to a far future date, with countsDown: false to count UP
+      Text(
+        timerInterval: startTime ... Date.distantFuture,
+        pauseTime: nil,
+        countsDown: false,
+        showsHours: true
+      )
+      if let label = durationLabel {
+        Text("/ \(label)")
+      }
+    }
     .monospacedDigit()
     .foregroundStyle(color ?? .primary)
   }

--- a/ios-files/LiveActivityWidget.swift
+++ b/ios-files/LiveActivityWidget.swift
@@ -371,8 +371,8 @@ struct ElapsedTimerText: View {
         countsDown: false
       )
       if let label = durationLabel {
-        Text("/ \(label)")
-          .layoutPriority(1)
+        Spacer(minLength: 8)
+        Text(label)
       }
     }
     .monospacedDigit()

--- a/ios-files/LiveActivityWidget.swift
+++ b/ios-files/LiveActivityWidget.swift
@@ -365,16 +365,14 @@ struct ElapsedTimerText: View {
 
   var body: some View {
     HStack(spacing: 4) {
-      // Use Text with timerInterval for Live Activities - iOS handles the updates automatically
-      // The range goes from startTime to a far future date, with countsDown: false to count UP
       Text(
         timerInterval: startTime ... Date.distantFuture,
         pauseTime: nil,
         countsDown: false
       )
-      .fixedSize()
       if let label = durationLabel {
         Text("/ \(label)")
+          .layoutPriority(1)
       }
     }
     .monospacedDigit()

--- a/ios-files/LiveActivityWidget.swift
+++ b/ios-files/LiveActivityWidget.swift
@@ -359,7 +359,7 @@ struct ElapsedTimerText: View {
     let minutes = (totalSeconds % 3600) / 60
     let seconds = totalSeconds % 60
     return hours > 0
-      ? String(format: "%d:%02d:%02d", hours, minutes, seconds)
+      ? String(format: "%02d:%02d:%02d", hours, minutes, seconds)
       : String(format: "%d:%02d", minutes, seconds)
   }
 
@@ -372,6 +372,7 @@ struct ElapsedTimerText: View {
         pauseTime: nil,
         countsDown: false
       )
+      .fixedSize()
       if let label = durationLabel {
         Text("/ \(label)")
       }

--- a/ios-files/LiveActivityWidget.swift
+++ b/ios-files/LiveActivityWidget.swift
@@ -364,18 +364,26 @@ struct ElapsedTimerText: View {
   }
 
   var body: some View {
-    HStack(spacing: 4) {
+    if let label = durationLabel {
+      HStack {
+        Text(
+          timerInterval: startTime ... Date.distantFuture,
+          pauseTime: nil,
+          countsDown: false
+        )
+        Spacer(minLength: 8)
+        Text(label)
+      }
+      .monospacedDigit()
+      .foregroundStyle(color ?? .primary)
+    } else {
       Text(
         timerInterval: startTime ... Date.distantFuture,
         pauseTime: nil,
         countsDown: false
       )
-      if let label = durationLabel {
-        Spacer(minLength: 8)
-        Text(label)
-      }
+      .monospacedDigit()
+      .foregroundStyle(color ?? .primary)
     }
-    .monospacedDigit()
-    .foregroundStyle(color ?? .primary)
   }
 }

--- a/ios/ExpoLiveActivityModule.swift
+++ b/ios/ExpoLiveActivityModule.swift
@@ -31,6 +31,9 @@ public class ExpoLiveActivityModule: Module {
       struct ElapsedTimer: Record {
         @Field
         var startDate: Double?
+
+        @Field
+        var endDate: Double?
       }
     }
 
@@ -316,6 +319,7 @@ public class ExpoLiveActivityModule: Module {
           dynamicIslandImageName: state.dynamicIslandImageName,
           smallImageName: state.smallImageName,
           elapsedTimerStartDateInMilliseconds: state.progressBar?.elapsedTimer?.startDate,
+          elapsedTimerEndDateInMilliseconds: state.progressBar?.elapsedTimer?.endDate,
           currentStep: state.progressBar?.currentStep,
           totalSteps: state.progressBar?.totalSteps
         )
@@ -363,6 +367,7 @@ public class ExpoLiveActivityModule: Module {
           dynamicIslandImageName: state.dynamicIslandImageName,
           smallImageName: state.smallImageName,
           elapsedTimerStartDateInMilliseconds: state.progressBar?.elapsedTimer?.startDate,
+          elapsedTimerEndDateInMilliseconds: state.progressBar?.elapsedTimer?.endDate,
           currentStep: state.progressBar?.currentStep,
           totalSteps: state.progressBar?.totalSteps
         )
@@ -399,6 +404,7 @@ public class ExpoLiveActivityModule: Module {
           dynamicIslandImageName: state.dynamicIslandImageName,
           smallImageName: state.smallImageName,
           elapsedTimerStartDateInMilliseconds: state.progressBar?.elapsedTimer?.startDate,
+          elapsedTimerEndDateInMilliseconds: state.progressBar?.elapsedTimer?.endDate,
           currentStep: state.progressBar?.currentStep,
           totalSteps: state.progressBar?.totalSteps
         )

--- a/ios/LiveActivityAttributes.swift
+++ b/ios/LiveActivityAttributes.swift
@@ -11,6 +11,7 @@ struct LiveActivityAttributes: ActivityAttributes {
     var dynamicIslandImageName: String?
     var smallImageName: String?
     var elapsedTimerStartDateInMilliseconds: Double?
+    var elapsedTimerEndDateInMilliseconds: Double?
     var currentStep: Int?
     var totalSteps: Int?
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export type DynamicIslandTimerType = 'circular' | 'digital'
 
 export type ElapsedTimer = {
   startDate: number // milliseconds timestamp (past time when timer started)
+  endDate?: number // when set: shows animated progress bar + "elapsed / duration" label
 }
 
 type ProgressBarType =
@@ -30,13 +31,6 @@ type ProgressBarType =
       date?: undefined
       progress?: undefined
       elapsedTimer?: ElapsedTimer
-      currentStep?: undefined
-      totalSteps?: undefined
-    }
-  | {
-      date?: undefined
-      progress: number
-      elapsedTimer: ElapsedTimer
       currentStep?: undefined
       totalSteps?: undefined
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,13 @@ type ProgressBarType =
     }
   | {
       date?: undefined
+      progress: number
+      elapsedTimer: ElapsedTimer
+      currentStep?: undefined
+      totalSteps?: undefined
+    }
+  | {
+      date?: undefined
       progress?: undefined
       elapsedTimer?: undefined
       currentStep?: number


### PR DESCRIPTION
## Problem

When using `progressBar` with an `elapsedTimer`, there was no way to simultaneously show an animated progress bar alongside the elapsed timer. The natural API for this is for `ElapsedTimer` to carry its own `endDate` — both ends of the interval are self-contained, the progress bar can animate natively, and the label can show \"elapsed / duration\".

## Solution

Add `endDate?: number` to `ElapsedTimer`. When set:

1. **Animated progress bar** — `ProgressView(timerInterval: startDate...endDate, countsDown: false)` fills live without any JS updates
2. **\"elapsed / duration\" label** — e.g. `1:00 / 30:00` using the existing `ElapsedTimerText` count-up plus a static formatted total duration

On resume after a pause, callers offset `startDate` to `Date.now() - elapsedMs` and set `endDate = startDate + maxDurationMs`, so both the timer and the bar reflect the correct accumulated position.

## Changes

| File | Change |
|------|--------|
| `src/index.ts` | Add `endDate?: number` to `ElapsedTimer` |
| `ios/LiveActivityAttributes.swift` | Add `elapsedTimerEndDateInMilliseconds: Double?` to `ContentState` |
| `ios/ExpoLiveActivityModule.swift` | Map `elapsedTimer.endDate` → `elapsedTimerEndDateInMilliseconds` in all three activity functions |
| `ios-files/LiveActivityMediumView.swift` | When `endDate` set: show `HStack(ElapsedTimerText + "/ duration")` + `styledLinearProgressView` with `ProgressView(timerInterval:)` |
| `ios-files/LiveActivitySmallView.swift` | Same for compact/CarPlay view; update `shouldShowProgressBar` |

## Usage

```ts
// Start
progressBar: { elapsedTimer: { startDate: Date.now(), endDate: Date.now() + maxDurationMs } }

// Resume after pause (accumulated elapsedMs)
const startDate = Date.now() - elapsedMs
progressBar: { elapsedTimer: { startDate, endDate: startDate + maxDurationMs } }

// Pause (clear progressBar to hide both timer and bar)
// just omit progressBar from the updateActivity call
```

## Screenshot

Below is what it looks like when you have an `endDate` for an ElapsedTimer
<img width="492" height="952" alt="Screenshot 2026-05-20 at 9 01 41 AM" src="https://github.com/user-attachments/assets/fcd8eb43-7c46-4ee5-b2d6-945035b82695" />
